### PR TITLE
New changes tracker & improvement to gspell support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(f_name):
 
 setup(
     name='typobuster',
-    version='0.1.2',
+    version='0.1.3',
     description='lightweight editor with text transformations and auto-correction',
     packages=find_packages(),
     include_package_data=True,

--- a/typobuster/langs/en_US.json
+++ b/typobuster/langs/en_US.json
@@ -62,6 +62,7 @@
   "search": "Search",
   "select-all": "Select All",
   "show": "Show",
+  "show-change-mark": "Show change mark",
   "show-stats": "Show text statistics",
   "snake-case": "snake_case",
   "sort-rows": "Sort rows",

--- a/typobuster/langs/pl_PL.json
+++ b/typobuster/langs/pl_PL.json
@@ -61,6 +61,7 @@
   "search": "Wyszukaj",
   "select-all": "Wybierz wszystko",
   "show": "Pokazuj",
+  "show-change-mark": "Pokazuj znak zmiany",
   "show-stats": "Pokazuj statystykę tekstu",
   "snakecase": "snake_case",
   "sort-rows": "Sortuj wiersze",

--- a/typobuster/main.py
+++ b/typobuster/main.py
@@ -236,6 +236,10 @@ class Typobuster(Gtk.Window):
         if self.search_bar:
             self.search_bar.stat_lbl.set_visible(self.settings["show-stats"])
 
+    def switch_change_visibility(self):
+        if self.search_bar:
+            self.search_bar.change_lbl.set_visible(self.settings["show-change"])
+
     def handle_keyboard_release(self, widget, event):
         if event.keyval == Gdk.KEY_Escape:
             self.source_view.grab_focus()
@@ -400,6 +404,12 @@ class Typobuster(Gtk.Window):
     def on_stats_cb_toggled(self, check_button):
         self.settings["show-stats"] = check_button.get_active()
         self.switch_stats_visibility()
+        save_settings(self.settings)
+        self.update_stats()
+
+    def on_change_cb_toggled(self, check_button):
+        self.settings["show-change"] = check_button.get_active()
+        self.switch_change_visibility()
         save_settings(self.settings)
         self.update_stats()
 
@@ -828,6 +838,7 @@ def main():
 
     window.show_all()
     window.switch_stats_visibility()
+    window.switch_change_visibility()
     Gtk.main()
 
 

--- a/typobuster/main.py
+++ b/typobuster/main.py
@@ -180,7 +180,7 @@ class Typobuster(Gtk.Window):
                 if not language:
                     language = Gspell.Language.get_default()
                 self.checker = Gspell.Checker.new(language)
-                print(f"Spell check: {language.get_code()}")
+                print(f"Spell check language: {language.get_code()}")
                 self.checker.set_language(language)
 
                 buffer = Gspell.TextBuffer.get_from_gtk_text_buffer(self.buffer)
@@ -278,8 +278,12 @@ class Typobuster(Gtk.Window):
             self.search_bar.search_entry.grab_focus()
 
     def on_close(self, widget, event):
-        self.settings["gspell-lang"] = self.checker.get_language().get_code()
-        save_settings(self.settings)
+        # remember last used spell check language
+        if self.settings["gspell-lang"] != self.checker.get_language().get_code():
+            print(f"Storing changed spell check language: {self.checker.get_language().get_code()}")
+            self.settings["gspell-lang"] = self.checker.get_language().get_code()
+            save_settings(self.settings)
+
         if self.text_changed():
             dialog = Gtk.MessageDialog(
                 transient_for=self,

--- a/typobuster/main.py
+++ b/typobuster/main.py
@@ -220,15 +220,17 @@ class Typobuster(Gtk.Window):
             self.search_bar.stat_lbl.set_text(
                 f'{self.voc["characters"]}: {len(selection)} {self.voc["words"]}: {len(selection.split())}')
 
-        self.mark_changes_in_window_title()
+        self.mark_changes_in_ui()
 
-    def mark_changes_in_window_title(self):
+    def mark_changes_in_ui(self):
         if self.text_changed():
             if not self.get_title().startswith("*"):
                 self.set_window_title(f"*{self.get_title()}")
+                self.search_bar.change_lbl.set_text("*")
         else:
             if self.get_title().startswith("*"):
                 self.set_window_title(self.get_title()[1:])
+                self.search_bar.change_lbl.set_text("")
 
     def switch_stats_visibility(self):
         if self.search_bar:

--- a/typobuster/tools.py
+++ b/typobuster/tools.py
@@ -110,7 +110,8 @@ def load_settings():
         "auto-indent": True,
         "whitespaces": False,
         "gspell-enable": False,
-        "show-stats": False
+        "show-stats": False,
+        "show-change": False
     }
     settings = load_json(config_path)
 

--- a/typobuster/tools.py
+++ b/typobuster/tools.py
@@ -90,6 +90,7 @@ def load_settings():
     config_path = os.path.join(config_dir(), "config")
 
     defaults = {
+        "gspell-lang": "",
         "gtk-font-name": "",
         "gtk-theme-name": "",
         "sanitize-spaces": True,

--- a/typobuster/ui_components.py
+++ b/typobuster/ui_components.py
@@ -523,7 +523,6 @@ class PreferencesDialog(Gtk.Dialog):
         self.show_all()
 
 
-
 class SearchBar(Gtk.Box):
     def __init__(self, parent_window):
         Gtk.Box.__init__(self, orientation=Gtk.Orientation.HORIZONTAL, spacing=3)
@@ -557,17 +556,20 @@ class SearchBar(Gtk.Box):
         btn.connect("clicked", self.replace)
 
         self.pos_lbl = Gtk.Label.new(f'{parent_window.voc["row"]}: 1 {parent_window.voc["column"]}: 0')
-        self.pack_end(self.pos_lbl, False, False, 6)
+        self.pack_end(self.pos_lbl, False, False, 3)
 
         self.stat_lbl = Gtk.Label.new("0")
-        self.pack_end(self.stat_lbl, False, False, 0)
+        self.pack_end(self.stat_lbl, False, False, 3)
 
         if parent_window.settings["syntax"] == "none":
             s_lbl = parent_window.voc["plain-text"]
         else:
             s_lbl = parent_window.syntax_dict[parent_window.settings["syntax"]]
         self.syntax_lbl = Gtk.Label.new(s_lbl)
-        self.pack_end(self.syntax_lbl, False, False, 6)
+        self.pack_end(self.syntax_lbl, False, False, 0)
+
+        self.change_lbl = Gtk.Label.new("")
+        self.pack_end(self.change_lbl, False, False, 0)
 
         self.show_all()
 

--- a/typobuster/ui_components.py
+++ b/typobuster/ui_components.py
@@ -506,12 +506,17 @@ class PreferencesDialog(Gtk.Dialog):
             self.spell_check_cb.set_tooltip_text(parent.voc["gspell-missing"])
         self.spell_check_cb.set_active(parent.settings["gspell-enable"])
         self.spell_check_cb.connect("toggled", parent.on_spell_check_switched)
-        self.grid.attach(self.spell_check_cb, 0, 6, 1, 1)
+        self.grid.attach(self.spell_check_cb, 1, 5, 1, 1)
 
         self.stats_cb = Gtk.CheckButton(label=parent.voc["show-stats"])
         self.stats_cb.set_active(parent.settings["show-stats"])
         self.stats_cb.connect("toggled", parent.on_stats_cb_toggled)
-        self.grid.attach(self.stats_cb, 0, 7, 1, 1)
+        self.grid.attach(self.stats_cb, 0, 6, 1, 1)
+
+        self.change_cb = Gtk.CheckButton(label=parent.voc["show-change-mark"])
+        self.change_cb.set_active(parent.settings["show-change"])
+        self.change_cb.connect("toggled", parent.on_change_cb_toggled)
+        self.grid.attach(self.change_cb, 1, 6, 1, 1)
 
         # OK Button
         hbox = Gtk.Box(Gtk.Orientation.HORIZONTAL, 0)


### PR DESCRIPTION
- The `unsaved_chages` variable replaced w/ the `text_changed()` method;
- added an asterisk to indicate that the text has been changed; you can find it in the window title and in the status bar (the latter must be enabled in preferences);
- added the "gspell-lang" config key, for the program to remember the last used spell check language on next run.